### PR TITLE
Update _fuzzificate_fuzzy_fact

### DIFF
--- a/fuzzy_expert/inference.py
+++ b/fuzzy_expert/inference.py
@@ -220,7 +220,7 @@ class DecompositionalInference:
         fact_value = self.fact_values[fact_name]
         xp = [xp for xp, _ in fact_value]
         fp = [fp for _, fp in fact_value]
-        self.variables[fact_name]._add_points_to_universe(xp)
+        self.variables[fact_name].add_points_to_universe(xp)
         self.fact_values[fact_name] = np.interp(
             x=self.variables[fact_name].universe, xp=xp, fp=fp
         )


### PR DESCRIPTION
- The `FuzzyVariable` class in the script `variable.py` includes a function `add_points_to_universe`. 
- But in `inference.py` in the function `_fuzzificate_fuzzy_fact` it has been incorrectly referred to as `_add_points_to_universe` which will cause error:

```  
Module FuzzyVariable has no attribute `_add_points_to_universe`
```
  
So change `self.variables[fact_name]._add_points_to_universe(xp)` to `self.variables[fact_name].add_points_to_universe(xp)`